### PR TITLE
Add a basic Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:6.11.1-alpine
+
+RUN apk add --update --no-cache curl
+RUN mkdir -p /usr/src/frontend
+WORKDIR /usr/src/frontend
+
+COPY package.json /usr/src/frontend/
+RUN npm install
+
+COPY . /usr/src/frontend
+RUN ./install-fonts.sh
+
+EXPOSE 8080
+CMD ["npm", "start"]

--- a/install-fonts.sh
+++ b/install-fonts.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+npm install bootstrap --save
+npm install uninett-bootstrap-theme --save
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxBold.woff http://mal.uninett.no/uninett-theme/fonts/colfaxBold.woff
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxLight.woff http://mal.uninett.no/uninett-theme/fonts/colfaxLight.woff
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxMedium.woff http://mal.uninett.no/uninett-theme/fonts/colfaxMedium.woff
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxRegular.woff http://mal.uninett.no/uninett-theme/fonts/colfaxRegular.woff
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxThin.woff http://mal.uninett.no/uninett-theme/fonts/colfaxThin.woff
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxRegularItalic.woff http://mal.uninett.no/uninett-theme/fonts/colfaxRegularItalic.woff
+
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxBold.svg http://mal.uninett.no/uninett-theme/fonts/colfaxBold.svg
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxLight.svg http://mal.uninett.no/uninett-theme/fonts/colfaxLight.svg
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxMedium.svg http://mal.uninett.no/uninett-theme/fonts/colfaxMedium.svg
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxRegular.svg http://mal.uninett.no/uninett-theme/fonts/colfaxRegular.svg
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxThin.svg http://mal.uninett.no/uninett-theme/fonts/colfaxThin.svg
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxRegularItalic.svg http://mal.uninett.no/uninett-theme/fonts/colfaxRegularItalic.svg
+
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxBold.ttf http://mal.uninett.no/uninett-theme/fonts/colfaxBold.ttf
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxLight.ttf http://mal.uninett.no/uninett-theme/fonts/colfaxLight.ttf
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxMedium.ttf http://mal.uninett.no/uninett-theme/fonts/colfaxMedium.ttf
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxRegular.ttf http://mal.uninett.no/uninett-theme/fonts/colfaxRegular.ttf
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxThin.ttf http://mal.uninett.no/uninett-theme/fonts/colfaxThin.ttf
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxRegularItalic.ttf http://mal.uninett.no/uninett-theme/fonts/colfaxRegularItalic.ttf
+
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxBold.eot http://mal.uninett.no/uninett-theme/fonts/colfaxBold.eot
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxLight.eot http://mal.uninett.no/uninett-theme/fonts/colfaxLight.eot
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxMedium.eot http://mal.uninett.no/uninett-theme/fonts/colfaxMedium.eot
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxRegular.eot http://mal.uninett.no/uninett-theme/fonts/colfaxRegular.eot
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxThin.eot http://mal.uninett.no/uninett-theme/fonts/colfaxThin.eot
+curl -o node_modules/uninett-bootstrap-theme/fonts/colfaxRegularItalic.eot http://mal.uninett.no/uninett-theme/fonts/colfaxRegularItalic.eot

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "main": "",
   "scripts": {
-    "start": "webpack-dev-server --content-base public ",
+    "start": "webpack-dev-server --content-base public --host 0.0.0.0 ",
     "build": "webpack --display-error-details -d"
   },
   "author": "Andreas Åkre Solberg <andreas.solberg@uninett.no>",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "axios": "^0.16.2",
     "babel-polyfill": "^6.23.0",
     "bootstrap": "*",
+    "extract-text-webpack-plugin": "^3.0.0",
     "history": "^4.6.3",
     "lodash": "^4.17.4",
     "react": "^15.6.1",


### PR DESCRIPTION
The purpose of this change is to add a Dockerfile which can be used to host the frontend in a Docker container, which is ex. useful when deploying it on k8s.